### PR TITLE
Update README.md to include portaudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Install uv](https://docs.astral.sh/uv/), the hyper modern Python package manager.
 - Setup environment `cp .env.sample .env` add your `OPENAI_API_KEY` and a `FIRECRAWL_API_KEY` for scraping.
 - Update `personalization.json` to fit your setup
+- Install portaudio `brew install portaudio`
 - Install dependencies `uv sync`
 - Run the realtime assistant `uv run main` or `uv run main --prompts "Hello, how are you?|What time is it?|Open Hacker News"`
 


### PR DESCRIPTION
I got this error because I didn't have portaudio.

```
[stderr]
src/pyaudio/device_api.c:9:10: fatal error: 'portaudio.h' file not found
    9 | #include "portaudio.h"
      |          ^~~~~~~~~~~~~
1 error generated.
error: command '/usr/bin/clang' failed with exit code 1
  Caused by: This error likely indicates that you need to install a library that provides "portaudio.h" for pyaudio@0.2.14
```